### PR TITLE
NOJIRA: transform rules correction example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The following is an example of how model transformation rules are used in bindin
                 domToModel: {
                     "": {
                         transform: {
-                            type: "fluid.transforms.numberToString",
+                            type: "fluid.transforms.stringToNumber",
                             inputPath: ""
                         }
                     }
@@ -71,7 +71,7 @@ The following is an example of how model transformation rules are used in bindin
                 modelToDom: {
                     "": {
                         transform: {
-                            type: "fluid.transforms.stringToNumber",
+                            type: "fluid.transforms.numberToString",
                             inputPath: ""
                         }
                     }


### PR DESCRIPTION
@the-t-in-rtf / @amb26 - I've been looking at `gpii-binder` for potential usage in one of my projects & I think there's an issue with the example long-style bindings vs. what the documentation says where the transformations used in the rules are swapped vs. what's described in the documentation. This PR corrects the transforms to match what the documentation says.
