### PR TITLE
GPII-3842: Added global grunt install to VM config.

### DIFF
--- a/.vagrant.yml
+++ b/.vagrant.yml
@@ -18,6 +18,7 @@ setup_job:
   stage: setup
   script:
     - choco install nodejs-lts -y
+    - npm install -g grunt    
     - do.ps1 -c "npm config set bin-links false --global"
 
 test_job:


### PR DESCRIPTION
Now that we can test in CI, minor VM configuration changes are needed.  See [GPII-3842](https://issues.gpii.net/browse/GPII-3842) for details.